### PR TITLE
Replace MoveList with unboxed vectors

### DIFF
--- a/src/Alias.hs
+++ b/src/Alias.hs
@@ -1,8 +1,10 @@
 module Alias where
-    
+
+import qualified Data.Vector.Unboxed as V
+
 type Square = Int
 type Bitboard = Int
 type Move = Int
-type MoveList = [Move]
-type Path = [Move]
+type MoveList = V.Vector Move
+type Path = [Move] -- Keep Path as a list for now
 type MagicFunc = (Square -> Int -> Bitboard)

--- a/src/Search/Perft.hs
+++ b/src/Search/Perft.hs
@@ -5,6 +5,7 @@ module Search.Perft where
 import Types ( Position(mover) )
 import Search.MakeMove ( makeMove )
 import Search.MoveGenerator ( isCheck, moves )
+import qualified Data.Vector.Unboxed as V
 import Control.Parallel.Strategies
     ( parList, rdeepseq, withStrategy )
 
@@ -13,6 +14,6 @@ perft !position !depth =
     if depth == 0
         then length notInCheckPositions
         else sum (withStrategy (parList rdeepseq) $ map (\x -> perft x (depth - 1)) notInCheckPositions)
-    where !newPositions = map (makeMove position) (moves position)
+    where !newPositions = map (makeMove position) (V.toList $ moves position)
           !notInCheckPositions = filter (\x -> not (isCheck x (mover position))) newPositions
 

--- a/src/Search/Quiesce.hs
+++ b/src/Search/Quiesce.hs
@@ -10,6 +10,7 @@ import Types
       Position(halfMoves, mover),
       HashEntry )
 import Alias ( Move, Bitboard, MoveList, Path )
+import qualified Data.Vector.Unboxed as V
 import Search.MoveGenerator (moves,isCheck,captureMoves)
 import Util.Utils ( timeMillis, toSquarePart )
 import Text.Printf ()
@@ -64,9 +65,9 @@ quiesce !position !low !high !ply searchState = do
 quiescePositions :: Position -> Bool -> [(Position,Move)]
 quiescePositions position inCheck =
     if null ps && inCheck
-        then filter (\(p,m) -> not (isCheck p $ mover position)) $ map (\m -> (makeMove position m, m)) (moves position)
+        then filter (\(p,m) -> not (isCheck p $ mover position)) $ map (\m -> (makeMove position m, m)) (V.toList $ moves position)
         else ps
     where
-        ps = filter (\(p,m) -> not (isCheck p $ mover position)) $ map (\m -> (makeMove position m, m)) (sortMoves position 0 $ captureMoves position)
+        ps = filter (\(p,m) -> not (isCheck p $ mover position)) $ map (\m -> (makeMove position m, m)) (V.toList $ sortMoves position 0 $ captureMoves position)
 
             

--- a/src/Search/Search.hs
+++ b/src/Search/Search.hs
@@ -11,6 +11,7 @@ import Types
       MoveScore(..),
       Position(halfMoves, mover) )
 import Alias ( Move, Bitboard, MoveList, Path )
+import qualified Data.Vector.Unboxed as V
 import Search.MoveGenerator (moves,isCheck)
 import Util.Utils ( timeMillis, toSquarePart, switchSide )
 import Text.Printf ()
@@ -39,7 +40,7 @@ import Control.Parallel.Strategies
 startSearch :: [Position] -> Int -> Int -> SearchState -> IO MoveScore
 startSearch (position:positions) maxDepth endTime searchState = do
     let theseMoves = sortMoves position 0 (moves position)
-    let newPositions = map (\move -> (makeMove position move,move)) theseMoves
+    let newPositions = map (\move -> (makeMove position move,move)) (V.toList theseMoves)
     let notInCheckPositions = filter (\(p,m) -> not (isCheck p (mover position))) newPositions
     result <- iterativeDeepening (position:positions) 1 maxDepth endTime (snd (head notInCheckPositions))
     setPv (msPath result) searchState

--- a/src/Search/SearchHelper.hs
+++ b/src/Search/SearchHelper.hs
@@ -9,6 +9,7 @@ import Types
       MoveScore(..),
       Position(halfMoves, mover, whiteKingBitboard,blackKingBitboard) )
 import Alias ( Move, Bitboard, MoveList, Path )
+import qualified Data.Vector.Unboxed as V
 import Search.MoveGenerator (moves,isCheck)
 import Util.Utils ( timeMillis, toSquarePart )
 import Text.Printf ()
@@ -29,7 +30,7 @@ import Util.Bitboards ( exactlyOneBitSet )
 canLeadToDrawByRepetition :: Position -> [Position] -> Bool
 canLeadToDrawByRepetition p ps
     | p `elem` ps = True
-    | or ([makeMove p m `elem` ps | m <- moves p]) = True
+    | or ([makeMove p m `elem` ps | m <- V.toList (moves p)]) = True
     | otherwise = False
 
 {-# INLINE mkMs #-}
@@ -39,15 +40,16 @@ mkMs (score, path) = MoveScore { msScore=score, msBound=Exact, msPath=path }
 {-# INLINE sortMoves #-}
 sortMoves :: Position -> Move -> MoveList -> MoveList
 sortMoves position hashMove moves = do
-    let scoredMoves = map (\m -> m + scoreMove position hashMove m `shiftL` 32) moves
-    map (0b0000000000000000000000000000000011111111111111111111111111111111 .&.) (sortBy (flip compare) scoredMoves)
+    let movesToList = V.toList moves
+    let scoredMoves = map (\m -> m + scoreMove position hashMove m `shiftL` 32) movesToList
+    V.fromList $ map (0b0000000000000000000000000000000011111111111111111111111111111111 .&.) (sortBy (flip compare) scoredMoves)
 
 {-# INLINE bestMoveFirst #-}
 bestMoveFirst :: Position -> Move -> [(Position,Move)]
 bestMoveFirst position bestMove = do
     let movesFromPosition = moves position
     let sortedMoves = sortMoves position bestMove movesFromPosition
-    let newPositions = map (\move -> (makeMove position move,move)) sortedMoves
+    let newPositions = map (\move -> (makeMove position move,move)) (V.toList sortedMoves)
     let notInCheckPositions = filter (\(p,m) -> not (isCheck p (mover position))) newPositions
     notInCheckPositions
 

--- a/src/Search/SearchHelper.hs
+++ b/src/Search/SearchHelper.hs
@@ -62,7 +62,7 @@ hashBound depth lockVal he =
 
 {-# INLINE newPositions #-}
 newPositions :: Position -> Move -> [(Position,Move)]
-newPositions position hashMove = map (\move -> (makeMove position move,move)) (sortMoves position hashMove (moves position))
+newPositions position hashMove = map (\move -> (makeMove position move,move)) (V.toList $ sortMoves position hashMove (moves position))
 
 kingCaptured :: Position -> Bool
 kingCaptured position = exactlyOneBitSet (whiteKingBitboard  position .|. blackKingBitboard position)


### PR DESCRIPTION
## My Note
- No noticable performance gain

## Summary
- Replace `[Move]` with `Data.Vector.Unboxed` for move lists
- Update move generation functions to work with vectors
- Modify move list operations to use vector operations like `V.concat` and `V.cons`
- Preallocate move buffers with empty vectors instead of empty lists

## Test plan
- Run perft tests to confirm move generation still produces the same results
- Test speed improvements in move generation by running performance benchmarks

Note: This is only the first step of this optimization. Further changes would include:
1. Updating other modules that use MoveList to leverage vector operations
2. Implementing more true preallocation with vector sizes

🤖 Generated with [Claude Code](https://claude.ai/code)